### PR TITLE
add stub for partial_sum

### DIFF
--- a/include/partial_sum.hpp
+++ b/include/partial_sum.hpp
@@ -17,6 +17,29 @@
 // Miscellaneous
 
 namespace bit {
+  
+/* [Will not implement]
+ * We don't support the addition of bit values. Users should use the second 
+ * overload of this function which allows the passing of a binary operation
+ * capable of adding two bit::bit_value's
+ *
+template <class InputIt, class OutputIt>
+bit_iterator<OutputIt> partial_sum(bit_iterator<InputIt> first, 
+    bit_iterator<InputIt> last, bit_iterator<OutputIt> d_first) {
+
+}
+*/
+
+// TODO
+template <class InputIt, class OutputIt, class BinaryOperation>
+bit_iterator<OutputIt> partial_sum(bit_iterator<InputIt> first,
+    bit_iterator<InputIt> last, bit_iterator<OutputIt> d_first,
+    BinaryOperation op) {
+
+    (first, last, op);
+    return d_first;
+}
+
 
 // ========================================================================== //
 } // namespace bit


### PR DESCRIPTION
Right now I'm going through and trying to find functions that we don't really want to implement so we can get them checked off the big non existent checklist. 

In all likelihood, functions which look the second overload of partial_sum will simply be deferred to the `std` implementation. There isn't much we can do in terms of optimization since we have no idea what the passed lambda will actually do.  It might be possible to optimize here if we provide the users some sort of function building blocks templates or similar. Until we are 100% sure on this, I'll leave these types of functions as todo's. 