### PR TITLE
Swap ranges

### DIFF
--- a/doc/papers/src/bit-algorithms.tex
+++ b/doc/papers/src/bit-algorithms.tex
@@ -137,38 +137,92 @@ Vincent Reverdy%
 \label{subsec:nonmodifyingAlgs}
 \subsubsection{\texttt{max\_element}}
 \paragraph{Description}
-Locates the largest element in a range \texttt{[first, last)} and returns an iterator to the element.
+Locates the largest element in a range \texttt{[first, last)} and returns an 
+iterator to the element.
 
 \paragraph{Implementation}
-Implementation is somewhat trivial. If \texttt{first} is LSB aligned (meaning it points to the 0th bit of a word) we perform a partial read from \text{first} to the closer of the MSB and the \text{last} iterator. Missing bits from the read are padded with 0 bits in the versions of the algorithm where a custom comparator is not passed. Next, we check the read word to see if it is greater than zero. If it is greater than zero, we know there is a set bit somewhere within the word. We can find the exact position of the set bit using \texttt{\_tzcnt} and return this position as an iterator. If \texttt{first} is not equal to \texttt{last}, we advance first to the 0th bit of the next word.
+Implementation is somewhat trivial. If \texttt{first} is LSB aligned (meaning 
+it points to the 0th bit of a word) we perform a partial read from \text{first} 
+to the closer of the MSB and the \text{last} iterator. Missing bits from the 
+read are padded with 0 bits in the versions of the algorithm where a custom 
+comparator is not passed. Next, we check the read word to see if it is greater 
+than zero. If it is greater than zero, we know there is a set bit somewhere 
+within the word. We can find the exact position of the set bit using 
+\texttt{\_tzcnt} and return this position as an iterator. If \texttt{first} is 
+not equal to \texttt{last}, we advance first to the 0th bit of the next word.
 
-While \texttt{first} is not equal to \texttt{last} and \texttt{last} is not in the same word as \texttt{first} (marking a final and partial word), we read whole words as normal and check for set bits as previously described.
+While \texttt{first} is not equal to \texttt{last} and \texttt{last} is not in 
+the same word as \texttt{first} (marking a final and partial word), we read 
+whole words as normal and check for set bits as previously described.
 
-If we arrive at a final, partial word, we again take a partial read of the bits remaining in the range, padding any missing bits with 0. We check for set bits as normal and return an iterator if a set bit was found.
+If we arrive at a final, partial word, we again take a partial read of the bits 
+remaining in the range, padding any missing bits with 0. We check for set bits 
+as normal and return an iterator if a set bit was found.
 
-If we have scanned the entire range and no set bits were found, we simply return \texttt{first}.
+If we have scanned the entire range and no set bits were found, we simply 
+return \texttt{first}.
 
 \subsubsection{\texttt{replace}}
 \paragraph{Description}
 Replaces 0s with 1s or vice versa in a range \texttt{[first, last)}.
 
 \paragraph{Implementation}
-Implementation follows a typical sequential processing of words in the range. First, the word pointed to by \texttt{first} is processed. Next, any full intermediary words within \texttt{[first, last)} are processed. Finally, if there is a remaining partial word bounded by \texttt{last}, it is handled.
+Implementation follows a typical sequential processing of words in the range. 
+First, the word pointed to by \texttt{first} is processed. Next, any full 
+intermediary words within \texttt{[first, last)} are processed. Finally, if 
+there is a remaining partial word bounded by \texttt{last}, it is handled.
 
-For full words, replacement is trivial. If we are replacing 0s with 1s, we simply set each word equal to -1. If we are replacing 1s with 0s, we set each word equal to 0. Partial words are slightly more complicated. For some processed partial word starting at bit index $i$ and ending at index $j$, we create a mask where bits are unset between $i$ and $j$ and set outside of the range. If we are replacing 0s with 1s, we do a bitwise or between the full word being processed and the mask. If we are replacing 1s with 0s, we do a bitwise and between the full word being processed and the XOR of the mask. This replaces bits within the bounds of the range while not modifying any bits outside the range.
+For full words, replacement is trivial. If we are replacing 0s with 1s, we 
+simply set each word equal to -1. If we are replacing 1s with 0s, we set each 
+word equal to 0. Partial words are slightly more complicated. For some processed 
+partial word starting at bit index $i$ and ending at index $j$, we create a mask 
+where bits are unset between $i$ and $j$ and set outside of the range. If we are 
+replacing 0s with 1s, we do a bitwise or between the full word being processed 
+and the mask. If we are replacing 1s with 0s, we do a bitwise and between the 
+full word being processed and the XOR of the mask. This replaces bits within 
+the bounds of the range while not modifying any bits outside the range.
 
 \subsubsection{\texttt{min\_element}}
 \paragraph{Description}
-Locates the smallest element in a range \texttt{[first, last)} and returns an iterator to the element.
+Locates the smallest element in a range \texttt{[first, last)} and returns an 
+iterator to the element.
 
 \paragraph{Implementation}
-Implementation follows a typical sequential processing of words in the range. First, the word pointed to by \texttt{first} is processed. Next, any full intermediary words within \texttt{[first, last)} are processed. Finally, if there is a remaining partial word bounded by \texttt{last}, it is handled.
+Implementation follows a typical sequential processing of words in the range. 
+First, the word pointed to by \texttt{first} is processed. Next, any full 
+intermediary words within \texttt{[first, last)} are processed. Finally, if 
+there is a remaining partial word bounded by \texttt{last}, it is handled.
 
-To locate 0's, we read words and pad any missing bits with 1s. We use a bitwise not to flip all of the bits so that we can use \texttt{\_tzcnt} (which counts the number of 0s from LSB to the first 1) to find the position of the first 0. We return an iterator to this position or \texttt{first} if no zero exists.
+To locate 0's, we read words and pad any missing bits with 1s. We use a 
+bitwise not to flip all of the bits so that we can use \texttt{\_tzcnt} 
+(which counts the number of 0s from LSB to the first 1) to find the position of 
+the first 0. We return an iterator to this position or \texttt{first} if no zero 
+exists.
 
 
 \subsection{Modifying Algorithms}
 \label{subsec:modifyingAlgs}
+
+\subsubsection{\texttt{swap_ranges}}
+\label{subsubsec:swap_ranges}
+\paragraph{Description}
+Swaps all elements in the range [first, last) starting from first and 
+proceeding to last - 1 to the second range beginning at first2. 
+The behavior is undefined if the sequences overlap.
+
+\paragraph{Implementation}
+    If \texttt{first1.position() == first2.position()} and they are of the same
+    word type, then we just perform swaps on entire words at a time. Otherwise,
+    let $n=\max(first1.position(), first2.position())$ and
+    $m = digits - n$. Then we first swap $m$ bits, which will align one of the
+    iterators. We then swap $n$ bits which will align the other iterator. We 
+    continue this until we reach the end. This gaurantees two swaps per word.
+
+\paragraph{Comments}
+\begin{itemize}
+    \item Not functional on ranges of different word types. 
+    \item It may be helpful to break the source code up into smaller functions. 
+\end{itemize}
 
 \subsubsection{\texttt{copy}}
 \label{subsubsec:copy}
@@ -191,8 +245,8 @@ See psuedocode below:
             \State Construct words of \texttt{dst\_word\_type}
             from the source and assign to destination.
         \EndWhile
-        \State If the last iterator is not aligned, copy the remaining bits to the
-            final word.
+        \State If the last iterator is not aligned, copy the remaining bits to 
+            the final word.
         \EndFunction
     \end{algorithmic}
 \end{algorithm}
@@ -208,15 +262,17 @@ See psuedocode below:
 \begin{itemize}
     \item[\texttt{shift\_left}] Shifts the elements towards the beginning of the 
             range. If $n \leq 0 || n \geq last - first$, there are no effects. 
-            Otherwise, for every integer $i$ in $[0, last - first - n)$, moves the 
-            element originally at position $first + n + i$ to position $first + i$. 
-            The moves are performed in increasing order of i starting from.
+            Otherwise, for every integer $i$ in $[0, last - first - n)$, moves 
+            the element originally at position $first + n + i$ to position 
+            $first + i$. The moves are performed in increasing order of i 
+            starting from.
     \item[\texttt{shift\_right}] Shifts the elements towards the end of the 
-        range. If $n \leq 0 || n \geq last - first$, there are no effects. Otherwise, 
-        for every integer $i$ in $[0, last - first - n)$, moves the element 
-        originally at position $first + i$ to position $first + n + i$. If ForwardIt 
-        meets the LegacyBidirectionalIterator requirements, then the moves are 
-        performed in decreasing order of $i$ starting from $last - first - n - 1$.
+        range. If $n \leq 0 || n \geq last - first$, there are no effects. 
+        Otherwise, for every integer $i$ in $[0, last - first - n)$, moves the 
+        element originally at position $first + i$ to position $first + n + i$. 
+        If ForwardIt meets the LegacyBidirectionalIterator requirements, then 
+        the moves are performed in decreasing order of $i$ starting from 
+        $last - first - n - 1$.
 \end{itemize}
 
 \paragraph{Implementation}

--- a/ext/bit/bit_details.hpp
+++ b/ext/bit/bit_details.hpp
@@ -326,10 +326,10 @@ constexpr T _bitblend(T src0, T src1, T start, T len) noexcept;
 // Bit exchange
 template <class T>
 constexpr void _bitexch(T& src0, T& src1, T msk) noexcept;
-template <class T>
-constexpr void _bitexch(T& src0, T& src1, T start, T len) noexcept;
-template <class T>
-constexpr void _bitexch(T& src0, T& src1, T start0, T start1, T len) noexcept;
+template <class T, class S>
+constexpr void _bitexch(T& src0, T& src1, S start, S len) noexcept;
+template <class T, class S>
+constexpr void _bitexch(T& src0, T& src1, S start0, S start1, S len) noexcept;
 
 // Bit compare
 template <class T>
@@ -775,12 +775,14 @@ constexpr void _bitexch(T& src0, T& src1, T msk) noexcept
 }
 
 // Replaces len bits of src0 by the ones of src1 starting at start
-template <class T>
-constexpr void _bitexch(T& src0, T& src1, T start, T len) noexcept
+template <class T, class S>
+constexpr void _bitexch(T& src0, T& src1, S start, S len) noexcept
 {
     static_assert(binary_digits<T>::value, "");
+    constexpr auto digits = binary_digits<T>::value;
     constexpr T one = 1;
-    const T msk = ((one << len) - one) << start;
+    const T msk = (len < digits) 
+        ? ((one << len) - one) << start : -1;
     src0 = src0 ^ static_cast<T>(src1 & msk);
     src1 = src1 ^ static_cast<T>(src0 & msk);
     src0 = src0 ^ static_cast<T>(src1 & msk);
@@ -790,12 +792,14 @@ constexpr void _bitexch(T& src0, T& src1, T start, T len) noexcept
 // Replaces len bits of src0 by the ones of src1 starting at start0
 // in src0 and start1 in src1. 
 // len <= digits-max(start0, start1)
-template <class T>
-constexpr void _bitexch(T& src0, T& src1, T start0, T start1, T len) noexcept
+template <class T, class S>
+constexpr void _bitexch(T& src0, T& src1, S start0, S start1, S len) noexcept
 {
     static_assert(binary_digits<T>::value, "");
+    constexpr auto digits = binary_digits<T>::value;
     constexpr T one = 1;
-    const T msk = ((one << len) - one);
+    const T msk = (len < digits) ?
+        ((one << len) - one) : -1;
     if (start0 >= start1) {
         src0 = src0 ^ (
                 static_cast<T>(src1 << (start0 - start1)) 

--- a/include/for_each_n.hpp
+++ b/include/for_each_n.hpp
@@ -27,8 +27,7 @@ namespace bit {
 template <class InputIt, class Size, class UnaryFunction>
 constexpr bit_iterator<InputIt> for_each_n(bit_iterator<InputIt> first,
     Size n, UnaryFunction f) {
-    return first;
-    //return std::for_each_n(first, n, f);
+    return std::for_each_n(first, n, f);
 }
 
 // Status: complete
@@ -36,8 +35,7 @@ template <class ExecutionPolicy, class ForwardIt, class Size,
     class UnaryFunction2> bit_iterator<ForwardIt> for_each_n (
     ExecutionPolicy&& policy, bit_iterator<ForwardIt> first, Size n,
     UnaryFunction2 f) {
-    return first;
-    //return std::for_each_n(std::forward<ExecutionPolicy>(policy), first, n, f);
+    return std::for_each_n(std::forward<ExecutionPolicy>(policy), first, n, f);
 }
 
 // ========================================================================== //

--- a/include/swap_ranges.hpp
+++ b/include/swap_ranges.hpp
@@ -1,31 +1,194 @@
 // ============================== SWAP RANGES ============================== //
-// Project: The Experimental Bit Algorithms Library
-// Name: swap_ranges.hpp
-// Description: bit_iterator overloads for std::swap_ranges
-// Creator: Vincent Reverdy
-// Contributor(s): 
-// License: BSD 3-Clause License
+// Project:         The Experimental Bit Algorithms Library
+// Name:            swap_ranges.hpp
+// Description:     bit_iterator overloads for std::swap_ranges
+// Creator:         Vincent Reverdy
+// Contributor(s):  Bryce Kille [2019]
+// License:         BSD 3-Clause License
 // ========================================================================== //
 #ifndef _SWAP_RANGES_HPP_INCLUDED
 #define _SWAP_RANGES_HPP_INCLUDED
 // ========================================================================== //
 
+
+
 // ============================== PREAMBLE ================================== //
 // C++ standard library
 // Project sources
+#include "../ext/bit/bit.hpp"
 // Third-party libraries
 // Miscellaneous
 namespace bit {
 // ========================================================================== //
 
+template< class ForwardIt1, class ForwardIt2 >
+constexpr bit_iterator<ForwardIt2> swap_ranges(
+        bit_iterator<ForwardIt1> first1, 
+        bit_iterator<ForwardIt1> last1,
+        bit_iterator<ForwardIt2> first2) 
+{
+    // Assertions
+    _assert_range_viability(first1, last1);
 
-// Status: to do
-template <class ForwardIt1, class ForwardIt2>
-constexpr bit_iterator<ForwardIt2> swap_ranges(bit_iterator<ForwardIt1> first1,
-    bit_iterator<ForwardIt1> last1, bit_iterator<ForwardIt2> first2) {
-    (first1, last1); 
-    return first2;
-} 
+    // Types and constants
+    using word_type1 = typename bit_iterator<ForwardIt1>::word_type;
+    using word_type2 = typename bit_iterator<ForwardIt2>::word_type;
+    using size_type1 = typename bit_iterator<ForwardIt1>::size_type;
+    using size_type2 = typename bit_iterator<ForwardIt2>::size_type;
+    constexpr size_type1 digits1 = binary_digits<word_type1>::value;
+    constexpr size_type2 digits2 = binary_digits<word_type2>::value;
+
+    // Initialization
+    //const bool is_first1_aligned = first1.position() == 0;
+    const bool is_last1_aligned = last1.position() == 0;
+    //const bool is_first2_aligned = first2.position() == 0;
+    ForwardIt1 it1 = first1.base();
+    ForwardIt2 it2 = first2.base();
+    
+    if (first1 == last1)
+        return first2;
+
+    if constexpr (digits1 == digits2) {
+        // All bits in first1 range are in 1 word
+        if (std::next(it1, is_last1_aligned) == last1.base()) {
+            size_type1 digits_to_copy = distance(first1, last1); 
+            if (first1.position() >= first2.position()) {
+                _bitexch<word_type1, size_type1>(
+                        *it1, 
+                        *it2, 
+                        first1.position(), 
+                        first2.position(),
+                        digits_to_copy
+                );
+            } else {
+                size_type1 partial_digits_to_copy = std::min(
+                        digits_to_copy,
+                        digits2 - first2.position()
+                );
+                _bitexch<word_type1, size_type1>(
+                        *it1, 
+                        *it2, 
+                        first1.position(), 
+                        first2.position(),
+                        partial_digits_to_copy
+                );
+                if (digits_to_copy > partial_digits_to_copy) {
+                    _bitexch<word_type1, size_type1>(
+                            *it1, 
+                            *(++it2), 
+                            first1.position() + partial_digits_to_copy, 
+                            0,
+                            digits_to_copy - partial_digits_to_copy
+                    );
+                }
+            }
+            return first2 + digits_to_copy;
+
+        // first1 range spans multiple words, 
+        // but both ranges have same alignment    
+        } else if (first1.position() == first2.position()) {
+            _bitexch<word_type1, size_type1>(
+                    *it1++, 
+                    *it2++, 
+                    first1.position(), 
+                    digits1 - first1.position()
+            );
+            while (it1 != last1.base()) {
+                std::swap(*it1++, *it2++);
+            }
+            if (!is_last1_aligned) {
+                _bitexch<word_type1, size_type1>(
+                        *it1, 
+                        *it2, 
+                        0,
+                        last1.position()
+                );
+            }
+            return bit_iterator<ForwardIt1>(it2, last1.position());
+
+        // first1 range spans mutliple words and is not aligned with first2
+        } else {
+            // 1. Align first1
+            size_type1 digits_to_copy = digits1 - first1.position();
+            if (first1.position() > first2.position()) {
+                _bitexch<word_type1, size_type1>(
+                        *it1++, 
+                        *it2, 
+                        first1.position(), 
+                        first2.position(),
+                        digits_to_copy
+                );
+            } else {
+                size_type1 partial_digits_to_copy = digits2 - first2.position();
+                _bitexch<word_type1, size_type1>(
+                        *it1, 
+                        *it2++, 
+                        first1.position(), 
+                        first2.position(),
+                        partial_digits_to_copy
+                );
+                _bitexch<word_type1, size_type1>(
+                        *it1++, 
+                        *it2, 
+                        first1.position() + partial_digits_to_copy, 
+                        0,
+                        digits_to_copy - partial_digits_to_copy
+                );
+            }
+            std::advance(first2, digits_to_copy);
+            digits_to_copy = digits2 - first2.position();
+            // 2. Exchange full words
+            while (it1 != last1.base()) {
+                _bitexch<word_type1, size_type1>(
+                        *it1,
+                        *it2++,
+                        0,
+                        first2.position(),
+                        digits_to_copy
+                );
+                _bitexch<word_type1, size_type1>(
+                        *it1++,
+                        *it2,
+                        digits_to_copy,
+                        0,
+                        digits1 - digits_to_copy
+                );
+            }
+            // Exchange last partial words
+            if (!is_last1_aligned) {
+                size_type2 partial_digits_to_copy = digits2 - first2.position();
+                if (last1.position() < partial_digits_to_copy) {
+                    _bitexch<word_type1, size_type1>(
+                            *it1,
+                            *it2,
+                            0,
+                            first2.position(),
+                            last1.position()
+                    );
+                    return bit_iterator(it2, first2.position()) + last1.position();
+                } else {
+                    _bitexch<word_type1, size_type1>(
+                            *it1,
+                            *it2++,
+                            0,
+                            first2.position(),
+                            partial_digits_to_copy
+                    );
+                    _bitexch<word_type1, size_type1>(
+                            *it1,
+                            *it2,
+                            partial_digits_to_copy,
+                            0,
+                            last1.position() - partial_digits_to_copy
+                    );
+                    return bit_iterator(it2, last1.position() - partial_digits_to_copy);
+                }
+            }
+            return bit_iterator(it2, first2.position());
+        }
+    }
+}
+
 
 // Status: to do
 template <class ExecutionPolicy, class ForwardIt1, class ForwardIt2>
@@ -38,6 +201,5 @@ bit_iterator<ForwardIt2> swap_ranges(ExecutionPolicy&& policy,
 
 // ========================================================================== //
 } // namespace bit
-
 #endif // _SWAP_RANGES_HPP_INCLUDED
 // ========================================================================== //

--- a/src/tests/for_each_n.hpp
+++ b/src/tests/for_each_n.hpp
@@ -27,7 +27,7 @@ TEMPLATE_TEST_CASE("for_each_n: is correct for trivial single word cases",
     TestType t = 0;
     bit_iterator<TestType*> first(&t, 0);
 
-    auto lambda = [](bit::bit_reference<TestType> br) { br = bit::bit1; }; 
+    //auto lambda = [](bit::bit_reference<TestType> br) { br = bit::bit1; }; 
 
     TestType expected_t = 0;
     bit_iterator<TestType*> expected_first(&expected_t, 0);

--- a/src/tests/min_element.hpp
+++ b/src/tests/min_element.hpp
@@ -29,7 +29,7 @@
 TEMPLATE_TEST_CASE("min_element: handles single word cases", "[min_element]",
     unsigned short, unsigned int, unsigned long, unsigned long long) {
 
-    constexpr std::size_t num_digits = bit::binary_digits<TestType>::value;
+    //constexpr std::size_t num_digits = bit::binary_digits<TestType>::value;
     constexpr TestType all_ones = bit::_all_ones(); 
     using bit_iterator_t = typename bit::bit_iterator<TestType*>;
 

--- a/src/tests/replace.hpp
+++ b/src/tests/replace.hpp
@@ -26,86 +26,86 @@
 
 // --------------------------- Replace Tests ---------------------------- //
 
-TEMPLATE_TEST_CASE("replace: handles single word cases", "[replace]",
-  unsigned short/*, unsigned int, unsigned long, unsigned long long*/) {
+//TEMPLATE_TEST_CASE("replace: handles single word cases", "[replace]",
+  //unsigned short[>, unsigned int, unsigned long, unsigned long long<]) {
 
-  TestType t = 0;
-  TestType all_ones = bit::_all_ones();
+  //TestType t = 0;
+  //TestType all_ones = bit::_all_ones();
 
-  bit::bit_iterator<TestType*> beg(&t, 0);
-  bit::bit_iterator<TestType*> end(&t + 1, 0);
-  bit::replace(beg, end, bit::bit0, bit::bit1);
-  REQUIRE(t == all_ones);
+  //bit::bit_iterator<TestType*> beg(&t, 0);
+  //bit::bit_iterator<TestType*> end(&t + 1, 0);
+  //bit::replace(beg, end, bit::bit0, bit::bit1);
+  //REQUIRE(t == all_ones);
 
-  bit::replace(beg, end, bit::bit1, bit::bit0);
-  REQUIRE(t == 0);
+  //bit::replace(beg, end, bit::bit1, bit::bit0);
+  //REQUIRE(t == 0);
 
-  bit::bit_iterator<TestType*> beg_plus_four(&t, 4); 
-  bit::replace(beg, beg_plus_four, bit::bit0, bit::bit1); 
-  REQUIRE(t == 15);
+  //bit::bit_iterator<TestType*> beg_plus_four(&t, 4); 
+  //bit::replace(beg, beg_plus_four, bit::bit0, bit::bit1); 
+  //REQUIRE(t == 15);
 
-  t = 0;
-  bit::replace(beg_plus_four, end, bit::bit0, bit::bit1);
-  REQUIRE(t == bit::_shift_towards_msb(all_ones, 4)); 
+  //t = 0;
+  //bit::replace(beg_plus_four, end, bit::bit0, bit::bit1);
+  //REQUIRE(t == bit::_shift_towards_msb(all_ones, 4)); 
 
-  t = static_cast<TestType>(-1);
-  bit::replace(beg_plus_four, end, bit::bit1, bit::bit0);
-  REQUIRE(t == 15);
+  //t = static_cast<TestType>(-1);
+  //bit::replace(beg_plus_four, end, bit::bit1, bit::bit0);
+  //REQUIRE(t == 15);
 
-  t = 0;
-  bit::bit_iterator<TestType*> beg_plus_seven(&t, 7);
-  bit::replace(beg_plus_four, beg_plus_seven, bit::bit0, bit::bit1);
-  REQUIRE(t == 112);
+  //t = 0;
+  //bit::bit_iterator<TestType*> beg_plus_seven(&t, 7);
+  //bit::replace(beg_plus_four, beg_plus_seven, bit::bit0, bit::bit1);
+  //REQUIRE(t == 112);
 
-  t = static_cast<TestType>(-1);
-  bit::replace(beg_plus_four, beg_plus_seven, bit::bit1, bit::bit0);
-  REQUIRE(t == static_cast<TestType>(all_ones ^ 112));
-}
+  //t = static_cast<TestType>(-1);
+  //bit::replace(beg_plus_four, beg_plus_seven, bit::bit1, bit::bit0);
+  //REQUIRE(t == static_cast<TestType>(all_ones ^ 112));
+//}
 
-TEMPLATE_PRODUCT_TEST_CASE("replace: handles multi word cases", 
-                           "[template][product]", 
-                           (std::vector, std::list, std::forward_list), 
-                           (unsigned short, unsigned int, unsigned long)) {
-    using container_type = TestType;
-    using cont_iter_type = typename container_type::iterator;
-    using word_type = typename container_type::value_type;
+//TEMPLATE_PRODUCT_TEST_CASE("replace: handles multi word cases", 
+                           //"[template][product]", 
+                           //(std::vector, std::list, std::forward_list), 
+                           //(unsigned short, unsigned int, unsigned long)) {
+    //using container_type = TestType;
+    //using cont_iter_type = typename container_type::iterator;
+    //using word_type = typename container_type::value_type;
 
-    constexpr word_type all_ones = bit::_all_ones();
+    //constexpr word_type all_ones = bit::_all_ones();
 
-    container_type cont = {0, 0, 0};
+    //container_type cont = {0, 0, 0};
 
-    bit_iterator first(cont.begin());
-    bit_iterator second(std::next(cont.begin()));
-    bit_iterator third(std::next(cont.begin(), 2));
-    bit_iterator last(cont.end());
+    //bit_iterator first(cont.begin());
+    //bit_iterator second(std::next(cont.begin()));
+    //bit_iterator third(std::next(cont.begin(), 2));
+    //bit_iterator last(cont.end());
 
-    bit::replace(first, last, bit::bit0, bit::bit1);
+    //bit::replace(first, last, bit::bit0, bit::bit1);
 
-    auto word_iter = cont.begin();
-    REQUIRE(*word_iter == all_ones);
-    REQUIRE(*std::next(word_iter) == all_ones); 
-    REQUIRE(*std::next(word_iter, 2) == all_ones);
+    //auto word_iter = cont.begin();
+    //REQUIRE(*word_iter == all_ones);
+    //REQUIRE(*std::next(word_iter) == all_ones); 
+    //REQUIRE(*std::next(word_iter, 2) == all_ones);
 
-    cont = {all_ones, all_ones, all_ones};
-    bit::replace(first, last, bit::bit1, bit::bit0);
-    REQUIRE(*word_iter == 0);
-    REQUIRE(*std::next(word_iter) == 0);
-    REQUIRE(*std::next(word_iter, 2) == 0);
+    //cont = {all_ones, all_ones, all_ones};
+    //bit::replace(first, last, bit::bit1, bit::bit0);
+    //REQUIRE(*word_iter == 0);
+    //REQUIRE(*std::next(word_iter) == 0);
+    //REQUIRE(*std::next(word_iter, 2) == 0);
 
-    constexpr std::size_t num_digits = bit::binary_digits<word_type>::value;
-    bit_iterator half_first = std::next(first, num_digits / 2);
-    bit_iterator half_second = std::next(second, num_digits / 2);
+    //constexpr std::size_t num_digits = bit::binary_digits<word_type>::value;
+    //bit_iterator half_first = std::next(first, num_digits / 2);
+    //bit_iterator half_second = std::next(second, num_digits / 2);
 
-    bit::replace(half_first, half_second, bit::bit0, bit::bit1);
-    REQUIRE(*word_iter == static_cast<word_type>(all_ones << (num_digits / 2))); 
-    REQUIRE(*std::next(word_iter) == static_cast<word_type>(all_ones >> (num_digits / 2)));
+    //bit::replace(half_first, half_second, bit::bit0, bit::bit1);
+    //REQUIRE(*word_iter == static_cast<word_type>(all_ones << (num_digits / 2))); 
+    //REQUIRE(*std::next(word_iter) == static_cast<word_type>(all_ones >> (num_digits / 2)));
 
-    cont = {0, 0, 0};
-    bit::replace(half_second, third, bit::bit0, bit::bit1);
-    REQUIRE(*word_iter == 0);
-    REQUIRE(*std::next(word_iter) == static_cast<word_type>(all_ones << (num_digits / 2)));
-    REQUIRE(*std::next(word_iter, 2) == 0);
-}
+    //cont = {0, 0, 0};
+    //bit::replace(half_second, third, bit::bit0, bit::bit1);
+    //REQUIRE(*word_iter == 0);
+    //REQUIRE(*std::next(word_iter) == static_cast<word_type>(all_ones << (num_digits / 2)));
+    //REQUIRE(*std::next(word_iter, 2) == 0);
+//}
 
 // -------------------------------------------------------------------------- //
 

--- a/src/tests/replace.hpp
+++ b/src/tests/replace.hpp
@@ -26,86 +26,86 @@
 
 // --------------------------- Replace Tests ---------------------------- //
 
-//TEMPLATE_TEST_CASE("replace: handles single word cases", "[replace]",
-  //unsigned short[>, unsigned int, unsigned long, unsigned long long<]) {
+TEMPLATE_TEST_CASE("replace: handles single word cases", "[replace]",
+  unsigned short[>, unsigned int, unsigned long, unsigned long long<]) {
 
-  //TestType t = 0;
-  //TestType all_ones = bit::_all_ones();
+  TestType t = 0;
+  TestType all_ones = bit::_all_ones();
 
-  //bit::bit_iterator<TestType*> beg(&t, 0);
-  //bit::bit_iterator<TestType*> end(&t + 1, 0);
-  //bit::replace(beg, end, bit::bit0, bit::bit1);
-  //REQUIRE(t == all_ones);
+  bit::bit_iterator<TestType*> beg(&t, 0);
+  bit::bit_iterator<TestType*> end(&t + 1, 0);
+  bit::replace(beg, end, bit::bit0, bit::bit1);
+  REQUIRE(t == all_ones);
 
-  //bit::replace(beg, end, bit::bit1, bit::bit0);
-  //REQUIRE(t == 0);
+  bit::replace(beg, end, bit::bit1, bit::bit0);
+  REQUIRE(t == 0);
 
-  //bit::bit_iterator<TestType*> beg_plus_four(&t, 4); 
-  //bit::replace(beg, beg_plus_four, bit::bit0, bit::bit1); 
-  //REQUIRE(t == 15);
+  bit::bit_iterator<TestType*> beg_plus_four(&t, 4); 
+  bit::replace(beg, beg_plus_four, bit::bit0, bit::bit1); 
+  REQUIRE(t == 15);
 
-  //t = 0;
-  //bit::replace(beg_plus_four, end, bit::bit0, bit::bit1);
-  //REQUIRE(t == bit::_shift_towards_msb(all_ones, 4)); 
+  t = 0;
+  bit::replace(beg_plus_four, end, bit::bit0, bit::bit1);
+  REQUIRE(t == bit::_shift_towards_msb(all_ones, 4)); 
 
-  //t = static_cast<TestType>(-1);
-  //bit::replace(beg_plus_four, end, bit::bit1, bit::bit0);
-  //REQUIRE(t == 15);
+  t = static_cast<TestType>(-1);
+  bit::replace(beg_plus_four, end, bit::bit1, bit::bit0);
+  REQUIRE(t == 15);
 
-  //t = 0;
-  //bit::bit_iterator<TestType*> beg_plus_seven(&t, 7);
-  //bit::replace(beg_plus_four, beg_plus_seven, bit::bit0, bit::bit1);
-  //REQUIRE(t == 112);
+  t = 0;
+  bit::bit_iterator<TestType*> beg_plus_seven(&t, 7);
+  bit::replace(beg_plus_four, beg_plus_seven, bit::bit0, bit::bit1);
+  REQUIRE(t == 112);
 
-  //t = static_cast<TestType>(-1);
-  //bit::replace(beg_plus_four, beg_plus_seven, bit::bit1, bit::bit0);
-  //REQUIRE(t == static_cast<TestType>(all_ones ^ 112));
-//}
+  t = static_cast<TestType>(-1);
+  bit::replace(beg_plus_four, beg_plus_seven, bit::bit1, bit::bit0);
+  REQUIRE(t == static_cast<TestType>(all_ones ^ 112));
+}
 
-//TEMPLATE_PRODUCT_TEST_CASE("replace: handles multi word cases", 
-                           //"[template][product]", 
-                           //(std::vector, std::list, std::forward_list), 
-                           //(unsigned short, unsigned int, unsigned long)) {
-    //using container_type = TestType;
-    //using cont_iter_type = typename container_type::iterator;
-    //using word_type = typename container_type::value_type;
+TEMPLATE_PRODUCT_TEST_CASE("replace: handles multi word cases", 
+                           "[template][product]", 
+                           (std::vector, std::list, std::forward_list), 
+                           (unsigned short, unsigned int, unsigned long)) {
+    using container_type = TestType;
+    using cont_iter_type = typename container_type::iterator;
+    using word_type = typename container_type::value_type;
 
-    //constexpr word_type all_ones = bit::_all_ones();
+    constexpr word_type all_ones = bit::_all_ones();
 
-    //container_type cont = {0, 0, 0};
+    container_type cont = {0, 0, 0};
 
-    //bit_iterator first(cont.begin());
-    //bit_iterator second(std::next(cont.begin()));
-    //bit_iterator third(std::next(cont.begin(), 2));
-    //bit_iterator last(cont.end());
+    bit_iterator first(cont.begin());
+    bit_iterator second(std::next(cont.begin()));
+    bit_iterator third(std::next(cont.begin(), 2));
+    bit_iterator last(cont.end());
 
-    //bit::replace(first, last, bit::bit0, bit::bit1);
+    bit::replace(first, last, bit::bit0, bit::bit1);
 
-    //auto word_iter = cont.begin();
-    //REQUIRE(*word_iter == all_ones);
-    //REQUIRE(*std::next(word_iter) == all_ones); 
-    //REQUIRE(*std::next(word_iter, 2) == all_ones);
+    auto word_iter = cont.begin();
+    REQUIRE(*word_iter == all_ones);
+    REQUIRE(*std::next(word_iter) == all_ones); 
+    REQUIRE(*std::next(word_iter, 2) == all_ones);
 
-    //cont = {all_ones, all_ones, all_ones};
-    //bit::replace(first, last, bit::bit1, bit::bit0);
-    //REQUIRE(*word_iter == 0);
-    //REQUIRE(*std::next(word_iter) == 0);
-    //REQUIRE(*std::next(word_iter, 2) == 0);
+    cont = {all_ones, all_ones, all_ones};
+    bit::replace(first, last, bit::bit1, bit::bit0);
+    REQUIRE(*word_iter == 0);
+    REQUIRE(*std::next(word_iter) == 0);
+    REQUIRE(*std::next(word_iter, 2) == 0);
 
-    //constexpr std::size_t num_digits = bit::binary_digits<word_type>::value;
-    //bit_iterator half_first = std::next(first, num_digits / 2);
-    //bit_iterator half_second = std::next(second, num_digits / 2);
+    constexpr std::size_t num_digits = bit::binary_digits<word_type>::value;
+    bit_iterator half_first = std::next(first, num_digits / 2);
+    bit_iterator half_second = std::next(second, num_digits / 2);
 
-    //bit::replace(half_first, half_second, bit::bit0, bit::bit1);
-    //REQUIRE(*word_iter == static_cast<word_type>(all_ones << (num_digits / 2))); 
-    //REQUIRE(*std::next(word_iter) == static_cast<word_type>(all_ones >> (num_digits / 2)));
+    bit::replace(half_first, half_second, bit::bit0, bit::bit1);
+    REQUIRE(*word_iter == static_cast<word_type>(all_ones << (num_digits / 2))); 
+    REQUIRE(*std::next(word_iter) == static_cast<word_type>(all_ones >> (num_digits / 2)));
 
-    //cont = {0, 0, 0};
-    //bit::replace(half_second, third, bit::bit0, bit::bit1);
-    //REQUIRE(*word_iter == 0);
-    //REQUIRE(*std::next(word_iter) == static_cast<word_type>(all_ones << (num_digits / 2)));
-    //REQUIRE(*std::next(word_iter, 2) == 0);
-//}
+    cont = {0, 0, 0};
+    bit::replace(half_second, third, bit::bit0, bit::bit1);
+    REQUIRE(*word_iter == 0);
+    REQUIRE(*std::next(word_iter) == static_cast<word_type>(all_ones << (num_digits / 2)));
+    REQUIRE(*std::next(word_iter, 2) == 0);
+}
 
 // -------------------------------------------------------------------------- //
 

--- a/src/tests/swap_ranges.hpp
+++ b/src/tests/swap_ranges.hpp
@@ -1,0 +1,306 @@
+// =========================== SWAP_RANGES TESTS ============================ //
+// Project:         The Experimental Bit Algorithms Library
+// Name:            swap_ranges.hpp
+// Description:     Tests for shift_left and shift_right algorithms 
+// Creator:         Vincent Reverdy
+// Contributor(s):  Bryce Kille [2019]
+// License:         BSD 3-Clause License
+// ========================================================================== //
+#ifndef _SWAP_RANGES_TESTS_HPP_INCLUDED
+#define _SWAP_RANGES_TESTS_HPP_INCLUDED
+// ========================================================================== //
+
+
+
+// ============================== PREAMBLE ================================== //
+// C++ standard library
+// Project sources
+#include "test_root.cc"
+#include "../../ext/bit/bit.hpp"
+// Third-party libraries
+// Miscellaneous
+// ========================================================================== //
+
+
+
+// --------------------------- swap_ranges Tests ---------------------------- //
+TEMPLATE_PRODUCT_TEST_CASE("swap_ranges: single word", 
+                           "[template][product]", 
+                           (std::vector, std::list, std::forward_list), 
+                           (unsigned char, unsigned short, unsigned int,
+                            unsigned long)) {
+    using container_type = TestType;
+    using num_type = typename container_type::value_type;
+    auto container_size = 4;
+    auto digits = bit::binary_digits<num_type>::value;
+    container_type bitcont1 = make_random_container<container_type>
+                                     (container_size); //, 0, 0);
+    container_type bitcont2 = make_random_container<container_type, unsigned short>
+                                     (container_size); //, std::numeric_limits<num_type>::max(),
+                                      //std::numeric_limits<num_type>::max());
+    auto boolcont1 = bitcont_to_boolcont(bitcont1);
+    auto boolcont2 = bitcont_to_boolcont(bitcont2);
+    auto bfirst1 = bit::bit_iterator<decltype(std::begin(bitcont1))>(std::begin(bitcont1));
+    auto blast1 = bit::bit_iterator<decltype(std::end(bitcont1))>(std::end(bitcont1));
+    auto bfirst2 = bit::bit_iterator<decltype(std::begin(bitcont2))>(std::begin(bitcont2));
+    auto blast2 = bit::bit_iterator<decltype(std::end(bitcont2))>(std::end(bitcont2));
+    auto bool_first1 = std::begin(boolcont1);
+    auto bool_last2 = std::end(boolcont2);
+    auto bool_first2 = std::begin(boolcont2);
+    auto bool_last1 = std::end(boolcont1);
+    auto bool_first1_t = bool_first1;
+    auto bool_first2_t = bool_first2;
+    auto bfirst1_t = bfirst1;
+    auto bfirst2_t = bfirst2;
+    auto bool_last1_t = bool_last1;
+    auto blast1_t = blast1;
+
+    std::advance(bfirst1_t, digits);
+    std::advance(bool_first1_t, digits);
+    auto bret = bit::swap_ranges(bfirst1, bfirst1_t, bfirst2);
+    auto bool_ret = std::swap_ranges(bool_first1, bool_first1_t, bool_first2);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+
+    bfirst1_t = std::next(bfirst1, 2);
+    bool_first1_t = std::next(bool_first1, 2);
+    blast1_t = std::next(bfirst1, digits-2);
+    bool_last1_t = std::next(bool_first1, digits-2);
+    bret = bit::swap_ranges(bfirst1, blast1_t, bfirst2);
+    bool_ret = std::swap_ranges(bool_first1, bool_last1_t, bool_first2);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+
+    bfirst1_t = std::next(bfirst1, 3);
+    bool_first1_t = std::next(bool_first1, 3);
+    blast1_t = std::next(bfirst1, digits-2);
+    bool_last1_t = std::next(bool_first1, digits-2);
+    bfirst2_t = std::next(bfirst1, 7);
+    bool_first2_t = std::next(bool_first1, 7);
+    bret = bit::swap_ranges(bfirst1, blast1_t, bfirst2);
+    bool_ret = std::swap_ranges(bool_first1, bool_last1_t, bool_first2);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("swap_ranges: multiple words aligned", 
+                           "[template][product]", 
+                           (std::vector, std::list, std::forward_list), 
+                           (unsigned char, unsigned short, unsigned int,
+                            unsigned long)) {
+    using container_type = TestType;
+    using num_type = typename container_type::value_type;
+    auto container_size = 5;
+    auto digits = bit::binary_digits<num_type>::value;
+    container_type bitcont1 = make_random_container<container_type>
+                                     (container_size); //, 0, 0);
+    container_type bitcont2 = make_random_container<container_type, unsigned short>
+                                     (container_size); //, std::numeric_limits<num_type>::max(),
+                                      //std::numeric_limits<num_type>::max());
+    auto boolcont1 = bitcont_to_boolcont(bitcont1);
+    auto boolcont2 = bitcont_to_boolcont(bitcont2);
+    auto bfirst1 = bit::bit_iterator<decltype(std::begin(bitcont1))>(std::begin(bitcont1));
+    auto blast1 = bit::bit_iterator<decltype(std::end(bitcont1))>(std::end(bitcont1));
+    auto bfirst2 = bit::bit_iterator<decltype(std::begin(bitcont2))>(std::begin(bitcont2));
+    auto blast2 = bit::bit_iterator<decltype(std::end(bitcont2))>(std::end(bitcont2));
+    auto bool_first1 = std::begin(boolcont1);
+    auto bool_last1 = std::end(boolcont1);
+    auto bool_first2 = std::begin(boolcont2);
+    auto bool_last2 = std::end(boolcont2);
+    auto bool_first1_t = bool_first1;
+    auto bool_first2_t = bool_first2;
+    auto bfirst1_t = bfirst1;
+    auto bfirst2_t = bfirst2;
+    auto bool_last1_t = bool_last1;
+    auto blast1_t = blast1;
+
+    blast1_t = std::next(bfirst1, digits*2);
+    bool_last1_t = std::next(bool_first1, digits*2);
+    auto bret = bit::swap_ranges(bfirst1_t, blast1_t, bfirst2_t);
+    auto bool_ret = std::swap_ranges(bool_first1_t, bool_last1_t, bool_first2_t);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+
+    blast1_t = std::next(bfirst1, digits*2-5);
+    bool_last1_t = std::next(bool_first1, digits*2-5);
+    bret = bit::swap_ranges(bfirst1_t, blast1_t, bfirst2_t);
+    bool_ret = std::swap_ranges(bool_first1_t, bool_last1_t, bool_first2_t);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+
+    bfirst1_t = std::next(bfirst1, 3);
+    bool_first1_t = std::next(bool_first1, 3);
+    bfirst2_t = std::next(bfirst2, 3);
+    bool_first2_t = std::next(bool_first2, 3);
+    blast1_t = std::next(bfirst1, digits*2-5);
+    bool_last1_t = std::next(bool_first1, digits*2-5);
+    bret = bit::swap_ranges(bfirst1_t, blast1_t, bfirst2_t);
+    bool_ret = std::swap_ranges(bool_first1_t, bool_last1_t, bool_first2_t);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+
+    bfirst1_t = std::next(bfirst1, digits-1);
+    bool_first1_t = std::next(bool_first1, digits-1);
+    bfirst2_t = std::next(bfirst2, digits-1);
+    bool_first2_t = std::next(bool_first2, digits-1);
+    blast1_t = std::next(bfirst1, digits*4+1);
+    bool_last1_t = std::next(bool_first1, digits*4+1);
+    bret = bit::swap_ranges(bfirst1_t, blast1_t, bfirst2_t);
+    bool_ret = std::swap_ranges(bool_first1_t, bool_last1_t, bool_first2_t);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("swap_ranges: multiple words unaligned", 
+                           "[template][product]", 
+                           (std::vector, std::list, std::forward_list), 
+                           (unsigned char, unsigned short, unsigned int,
+                            unsigned long)) {
+    using container_type = TestType;
+    using num_type = typename container_type::value_type;
+    auto container_size = 5;
+    auto digits = bit::binary_digits<num_type>::value;
+    container_type bitcont1 = make_random_container<container_type>
+                                     (container_size); //, 0, 0);
+    container_type bitcont2 = make_random_container<container_type, unsigned short>
+                                     (container_size); //, std::numeric_limits<num_type>::max(),
+                                      //std::numeric_limits<num_type>::max());
+    auto boolcont1 = bitcont_to_boolcont(bitcont1);
+    auto boolcont2 = bitcont_to_boolcont(bitcont2);
+    auto bfirst1 = bit::bit_iterator<decltype(std::begin(bitcont1))>(std::begin(bitcont1));
+    auto blast1 = bit::bit_iterator<decltype(std::end(bitcont1))>(std::end(bitcont1));
+    auto bfirst2 = bit::bit_iterator<decltype(std::begin(bitcont2))>(std::begin(bitcont2));
+    auto blast2 = bit::bit_iterator<decltype(std::end(bitcont2))>(std::end(bitcont2));
+    auto bool_first1 = std::begin(boolcont1);
+    auto bool_last1 = std::end(boolcont1);
+    auto bool_first2 = std::begin(boolcont2);
+    auto bool_last2 = std::end(boolcont2);
+    auto bool_first1_t = bool_first1;
+    auto bool_first2_t = bool_first2;
+    auto bfirst1_t = bfirst1;
+    auto bfirst2_t = bfirst2;
+    auto bool_last1_t = bool_last1;
+    auto blast1_t = blast1;
+
+    blast1_t = std::next(bfirst1, digits*2);
+    bool_last1_t = std::next(bool_first1, digits*2);
+    bfirst1_t = std::next(bfirst1, 2);
+    bool_first1_t = std::next(bool_first1, 2);
+    bfirst2_t = std::next(bfirst2, 3);
+    bool_first2_t = std::next(bool_first2, 3);
+    auto bret = bit::swap_ranges(bfirst1_t, blast1_t, bfirst2_t);
+    auto bool_ret = std::swap_ranges(bool_first1_t, bool_last1_t, bool_first2_t);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+
+    blast1_t = std::next(bfirst1, digits*2-5);
+    bool_last1_t = std::next(bool_first1, digits*2-5);
+    bfirst1_t = std::next(bfirst1, 4);
+    bool_first1_t = std::next(bool_first1, 4);
+    bfirst2_t = std::next(bfirst2, 3);
+    bool_first2_t = std::next(bool_first2, 3);
+    bret = bit::swap_ranges(bfirst1_t, blast1_t, bfirst2_t);
+    bool_ret = std::swap_ranges(bool_first1_t, bool_last1_t, bool_first2_t);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+
+    bfirst1_t = std::next(bfirst1, digits-1);
+    bool_first1_t = std::next(bool_first1, digits-1);
+    bfirst2_t = std::next(bfirst2, digits-2);
+    bool_first2_t = std::next(bool_first2, digits-2);
+    blast1_t = std::next(bfirst1, digits*2-5);
+    bool_last1_t = std::next(bool_first1, digits*2-5);
+    bret = bit::swap_ranges(bfirst1_t, blast1_t, bfirst2_t);
+    bool_ret = std::swap_ranges(bool_first1_t, bool_last1_t, bool_first2_t);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+
+    bfirst1_t = std::next(bfirst1, digits-2);
+    bool_first1_t = std::next(bool_first1, digits-2);
+    bfirst2_t = std::next(bfirst2, digits-1);
+    bool_first2_t = std::next(bool_first2, digits-1);
+    blast1_t = std::next(bfirst1, digits*4+1);
+    bool_last1_t = std::next(bool_first1, digits*4+1);
+    bret = bit::swap_ranges(bfirst1_t, blast1_t, bfirst2_t);
+    bool_ret = std::swap_ranges(bool_first1_t, bool_last1_t, bool_first2_t);
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst2, bret) == std::distance(bool_first2, bool_ret));
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("swap_ranges: multiple words unaligned same container", 
+                           "[template][product]", 
+                           (std::vector, std::list, std::forward_list), 
+                           (unsigned char, unsigned short, unsigned int,
+                            unsigned long)) {
+    using container_type = TestType;
+    using num_type = typename container_type::value_type;
+    auto container_size = 7;
+    auto digits = bit::binary_digits<num_type>::value;
+    container_type bitcont1 = make_random_container<container_type>
+                                     (container_size); //, 0, 0);
+    container_type bitcont2 = make_random_container<container_type, unsigned short>
+                                     (container_size); //, std::numeric_limits<num_type>::max(),
+                                      //std::numeric_limits<num_type>::max());
+    auto boolcont1 = bitcont_to_boolcont(bitcont1);
+    auto bfirst1 = bit::bit_iterator<decltype(std::begin(bitcont1))>(std::begin(bitcont1));
+    auto blast1 = bit::bit_iterator<decltype(std::end(bitcont1))>(std::end(bitcont1));
+    auto bool_first1 = std::begin(boolcont1);
+    auto bool_last1 = std::end(boolcont1);
+
+    auto bret = bit::swap_ranges(
+            bfirst1, 
+            std::next(bfirst1, digits), 
+            std::next(bfirst1, digits+4)
+    );
+    auto bool_ret = std::swap_ranges(
+            bool_first1, 
+            std::next(bool_first1, digits), 
+            std::next(bool_first1, digits+4)
+    );
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::distance(bfirst1, bret) == std::distance(bool_first1, bool_ret));
+    
+    bret = bit::swap_ranges(
+            bfirst1, 
+            std::next(bfirst1, 4), 
+            std::next(bfirst1, 4)
+    );
+    bool_ret = std::swap_ranges(
+            bool_first1, 
+            std::next(bool_first1, 4), 
+            std::next(bool_first1, 4)
+    );
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::distance(bfirst1, bret) == std::distance(bool_first1, bool_ret));
+
+    bret = bit::swap_ranges(
+            std::next(bfirst1, digits-3), 
+            std::next(bfirst1, digits+3), 
+            std::next(bfirst1, digits+4)
+    );
+    bool_ret = std::swap_ranges(
+            std::next(bool_first1, digits-3), 
+            std::next(bool_first1, digits+3), 
+            std::next(bool_first1, digits+4)
+    );
+    REQUIRE(std::equal(bool_first1, bool_last1, bfirst1, blast1, comparator));
+    REQUIRE(std::distance(bfirst1, bret) == std::distance(bool_first1, bool_ret));
+}
+// -------------------------------------------------------------------------- //
+
+
+
+// ========================================================================== //
+#endif // _SWAP_RANGES_TESTS_HPP_INCLUDED
+// ========================================================================== //


### PR DESCRIPTION
- Added `swap_ranges.hpp`, corresponding tests and documentation.
- Removed lines that caused warnings in the compiler (unused variables mostly)
- `replace()` is segfaulting on a test @gress2 