### PR TITLE
Removed for_each_n

### DIFF
--- a/include/for_each_n.hpp
+++ b/include/for_each_n.hpp
@@ -23,19 +23,19 @@ namespace bit {
 
 
 
-// Status: complete
+// Status: TODO (no for_each_n yet in STL)
 template <class InputIt, class Size, class UnaryFunction>
 constexpr bit_iterator<InputIt> for_each_n(bit_iterator<InputIt> first,
     Size n, UnaryFunction f) {
-    return std::for_each_n(first, n, f);
+    return first;
 }
 
-// Status: complete
+// Status: TODO (no for_each_n yet in STL)
 template <class ExecutionPolicy, class ForwardIt, class Size, 
     class UnaryFunction2> bit_iterator<ForwardIt> for_each_n (
     ExecutionPolicy&& policy, bit_iterator<ForwardIt> first, Size n,
     UnaryFunction2 f) {
-    return std::for_each_n(std::forward<ExecutionPolicy>(policy), first, n, f);
+    return first;
 }
 
 // ========================================================================== //

--- a/include/for_each_n.hpp
+++ b/include/for_each_n.hpp
@@ -27,6 +27,7 @@ namespace bit {
 template <class InputIt, class Size, class UnaryFunction>
 constexpr bit_iterator<InputIt> for_each_n(bit_iterator<InputIt> first,
     Size n, UnaryFunction f) {
+    n; f;
     return first;
 }
 
@@ -35,6 +36,7 @@ template <class ExecutionPolicy, class ForwardIt, class Size,
     class UnaryFunction2> bit_iterator<ForwardIt> for_each_n (
     ExecutionPolicy&& policy, bit_iterator<ForwardIt> first, Size n,
     UnaryFunction2 f) {
+    policy; n; f;
     return first;
 }
 


### PR DESCRIPTION
`for_each_n` is causing the CircleCI tests to fail since it is not yet present in the compilers. I have removed it for now and marked as TODO.