### PR TITLE
Working mismatch w/ tests

### DIFF
--- a/src/tests/mismatch.hpp
+++ b/src/tests/mismatch.hpp
@@ -1,89 +1,222 @@
 // ============================= MISMATCH TESTS ============================= //
-// Project: The Experimental Bit Algorithms Library
-// Name: mismatch.hpp
-// Description: tests for mismatch algorithm bit iterator overloads 
-// Creator: Vincent Reverdy
-// Contributor(s): Vincent Reverdy [2019]
-//                 Collin Gress [2019]
-// License: BSD 3-Clause License
+// Project:         The Experimental Bit Algorithms Library
+// Name:            mismatch.hpp
+// Description:     tests for mismatch algorithm bit iterator overloads 
+// Creator:         Vincent Reverdy
+// Contributor(s):  Vincent Reverdy [2019]
+//                  Bryce Kille [2019] 
+// License:         BSD 3-Clause License
 // ========================================================================== //
 #ifndef _MISMATCH_TESTS_HPP_INCLUDED
 #define _MISMATCH_TESTS_HPP_INCLUDED
 // ========================================================================== //
 
-// ============================== PREAMBLE ================================== //
+
+
+// =============================== PREAMBLE ================================= //
 // C++ standard library
 // Project sources
-#include "test_utils.hpp"
-// Third party libraries
-#include "catch2.hpp"
+#include "test_root.cc"
+#include "bit.hpp"
+// Third-party libraries
+// Miscellaneous
+// ========================================================================== //
 
-using bit::bit_iterator;
 
-TEMPLATE_TEST_CASE("Single number", "[mismatch]", unsigned short, unsigned int, 
-    unsigned long, unsigned long long) {
-    using num_type = TestType;
-    num_type n1 = 4;
-    num_type n2 = 8;
 
-    bit_iterator<num_type*> n1_beg(&n1, 0);
-    bit_iterator<num_type*> n2_beg(&n2, 0);
+// ----------------------------- Mismatch Tests ----------------------------- //
+TEMPLATE_PRODUCT_TEST_CASE("mismatch: multiple_word", 
+                           "[template][product]", 
+                           (std::vector, std::list, std::forward_list), 
+                           (unsigned short, unsigned int, unsigned long, unsigned long long)) {
 
-    bit_iterator<num_type*> n1_end(&n1 + 1, 0);
-    bit_iterator<num_type*> n2_end(&n2 + 1, 0);
+    using container_type = TestType;
+    using num_type = typename container_type::value_type;
+    auto container_size = 6;
+    auto digits = bit::binary_digits<num_type>::value;
+    container_type bitcont1 = make_random_container<container_type>
+                                     (container_size); //, 0, 0);
+    container_type bitcont2 = make_random_container<container_type>
+                                     (container_size); //, std::numeric_limits<num_type>::max(),
+                                      //std::numeric_limits<num_type>::max());
+    auto boolcont1 = bitcont_to_boolcont(bitcont1);
+    auto boolcont2 = bitcont_to_boolcont(bitcont2);
+    auto bfirst1 = bit::bit_iterator<decltype(std::begin(bitcont1))>(std::begin(bitcont1));
+    auto blast1 = bit::bit_iterator<decltype(std::end(bitcont1))>(std::end(bitcont1));
+    auto bfirst2 = bit::bit_iterator<decltype(std::begin(bitcont2))>(std::begin(bitcont2));
+    auto blast2 = bit::bit_iterator<decltype(std::end(bitcont2))>(std::end(bitcont2));
+    auto bool_first1 = std::begin(boolcont1);
+    auto bool_last1 = std::end(boolcont1);
+    auto bool_first2 = std::begin(boolcont2);
+    auto bool_last2 = std::end(boolcont2);
 
-    auto p = bit::mismatch(n1_beg, n1_end, n2_beg, n2_end);
+    auto bret = bit::mismatch(
+            bfirst1, 
+            blast1,
+            bfirst2
+    );
+    auto bool_ret = std::mismatch(
+            bool_first1, 
+            bool_last1, 
+            bool_first2
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
 
-    REQUIRE(p.first.position() == 2);
+    bret = bit::mismatch(
+            std::next(bfirst1, 9), 
+            blast1,
+            bfirst2
+    );
+    bool_ret = std::mismatch(
+            std::next(bool_first1, 9), 
+            bool_last1, 
+            bool_first2
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
+
+    bret = bit::mismatch(
+            std::next(bfirst1, 9), 
+            std::next(bfirst1, (container_size - 1)*digits - (digits/3)),
+            bfirst2
+    );
+    bool_ret = std::mismatch(
+            std::next(bool_first1, 9), 
+            std::next(bool_first1, (container_size - 1)*digits - (digits/3)),
+            bool_first2
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
+
+    bret = bit::mismatch(
+            bfirst1, 
+            blast1,
+            std::next(bfirst2, digits - 1)
+    );
+    bool_ret = std::mismatch(
+            bool_first1, 
+            bool_last1, 
+            std::next(bool_first2, digits - 1)
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
+
+    bret = bit::mismatch(
+            std::next(bfirst1, 9), 
+            blast1,
+            std::next(bfirst2, digits - 1)
+    );
+    bool_ret = std::mismatch(
+            std::next(bool_first1, 9), 
+            bool_last1, 
+            std::next(bool_first2, digits - 1)
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
+
+    bret = bit::mismatch(
+            std::next(bfirst1, 9), 
+            std::next(bfirst1, (container_size - 1)*digits - (digits/3)),
+            std::next(bfirst2, digits - 1)
+    );
+    bool_ret = std::mismatch(
+            std::next(bool_first1, 9), 
+            std::next(bool_first1, (container_size - 1)*digits - (digits/3)),
+            std::next(bool_first2, digits - 1)
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
 }
 
-TEMPLATE_TEST_CASE("Vector", "[mismatch]", unsigned short, unsigned int,
-    unsigned long, unsigned long long) {
-  
-    using vec_type = std::vector<TestType>;
+TEMPLATE_PRODUCT_TEST_CASE("mismatch: single_word", 
+                           "[template][product]", 
+                           (std::vector, std::list, std::forward_list), 
+                           (unsigned short, unsigned int, unsigned long, unsigned long long)) {
 
-    vec_type vec1 = {2, 3, 4, 5};
-    vec_type vec2 = {2, 3, 5, 4};
-    
-    bit_iterator<typename vec_type::iterator> b1(vec1.begin(), 0);
-    bit_iterator<typename vec_type::iterator> b2(vec2.begin(), 0);
-    bit_iterator<typename vec_type::iterator> e1(vec1.end(), 0);
-    bit_iterator<typename vec_type::iterator> e2(vec2.end(), 0);
+    using container_type = TestType;
+    using num_type = typename container_type::value_type;
+    auto container_size = 3;
+    auto digits = bit::binary_digits<num_type>::value;
+    container_type bitcont1 = make_random_container<container_type>
+                                     (container_size); //, 0, 0);
+    container_type bitcont2 = make_random_container<container_type>
+                                     (container_size); //, std::numeric_limits<num_type>::max(),
+                                      //std::numeric_limits<num_type>::max());
+    auto boolcont1 = bitcont_to_boolcont(bitcont1);
+    auto boolcont2 = bitcont_to_boolcont(bitcont2);
+    auto bfirst1 = bit::bit_iterator<decltype(std::begin(bitcont1))>(std::begin(bitcont1));
+    auto bfirst2 = bit::bit_iterator<decltype(std::begin(bitcont2))>(std::begin(bitcont2));
+    auto blast2 = bit::bit_iterator<decltype(std::end(bitcont2))>(std::end(bitcont2));
+    auto bool_first1 = std::begin(boolcont1);
+    auto bool_first2 = std::begin(boolcont2);
+    auto bool_last2 = std::end(boolcont2);
 
-    bit_iterator<typename vec_type::iterator> expected1(vec1.begin() + 2, 0);
-    bit_iterator<typename vec_type::iterator> expected2(vec2.begin() + 2, 0);
+    auto bret = bit::mismatch(
+            bfirst1, 
+            std::next(bfirst1, digits),
+            bfirst2
+    );
+    auto bool_ret = std::mismatch(
+            bool_first1, 
+            std::next(bool_first1, digits),
+            bool_first2
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
 
-    auto p = bit::mismatch(b1, e1, b2, e2); 
-     
-    REQUIRE(expected1.position() == p.first.position());
-    REQUIRE(*expected1 == *(p.first));
-    REQUIRE(expected2.position() == p.second.position());
-    REQUIRE(*expected2 == *(p.second));
+    bret = bit::mismatch(
+            std::next(bfirst1, 9), 
+            std::next(bfirst1, 9 + digits), 
+            bfirst2
+    );
+    bool_ret = std::mismatch(
+            std::next(bool_first1, 9), 
+            std::next(bool_first1, 9 + digits), 
+            bool_first2
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
+
+    bret = bit::mismatch(
+            std::next(bfirst1, 9), 
+            std::next(bfirst1, 5 + digits), 
+            bfirst2
+    );
+    bool_ret = std::mismatch(
+            std::next(bool_first1, 9), 
+            std::next(bool_first1, 5 + digits), 
+            bool_first2
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
+
+    bret = bit::mismatch(
+            std::next(bfirst1, 9), 
+            std::next(bfirst1, 5 + digits), 
+            std::next(bfirst2, 3)
+    );
+    bool_ret = std::mismatch(
+            std::next(bool_first1, 9), 
+            std::next(bool_first1, 5 + digits), 
+            std::next(bool_first2, 3)
+    );
+    REQUIRE(std::equal(bool_first2, bool_last2, bfirst2, blast2, comparator));
+    REQUIRE(std::distance(bfirst1, bret.first) == std::distance(bool_first1, bool_ret.first));
+    REQUIRE(std::distance(bfirst2, bret.second) == std::distance(bool_first2, bool_ret.second));
 }
+// -------------------------------------------------------------------------- //
 
-TEMPLATE_TEST_CASE("Misaligned vector works", "[mismatch]", 
-    unsigned short, unsigned int, unsigned long, unsigned long long) {
 
-    using vec_type = std::vector<TestType>;
-    
-    vec_type vec1 = {80, 24, 890}; // 890 =   001101111010
-    vec_type vec2 = {80, 24, 3116}; // 3116 = 110000101100 
-
-    using biter = bit::bit_iterator<typename vec_type::iterator>;
-
-    biter vec1_begin(vec1.begin());
-    biter vec1_end(vec1.end());
-    biter vec2_begin(vec2.begin());
-    biter vec2_end(vec2.end());
-
-    auto res = bit::mismatch(vec1_begin, vec1_end, vec2_begin, vec2_end);
-
-    REQUIRE(res.first.position() == 1);
-    REQUIRE(res.second.position() == 1);
-
-    REQUIRE(*(res.first.base()) == 890);
-    REQUIRE(*(res.second.base()) == 3116);
-}
 
 // ========================================================================== //
 #endif // _MISMATCH_TESTS_HPP_INCLUDED


### PR DESCRIPTION
Basic mismatch working with tests. It is not optimized, though. For example, in the `while` loop it would be better to check for equality first before computing the trailing zeros count.